### PR TITLE
Update DecoratorPattern.cpp

### DIFF
--- a/Lecture 13/C++ Code/DecoratorPattern.cpp
+++ b/Lecture 13/C++ Code/DecoratorPattern.cpp
@@ -26,7 +26,9 @@ public:
     CharacterDecorator(Character* c){
         this->character = c;
     }
-
+    virtual ~CharacterDecorator(){
+        delete character; // cleans up resources 
+    };
 };
 
 // Concrete Decorator: Height-Increasing Power-Up.
@@ -57,10 +59,6 @@ public:
     
     string getAbilities() const override {
         return character->getAbilities() + " with Star Power (Limited Time)";
-    }
-    
-    ~StarPowerUp() {
-        cout << "Destroying StarPowerUp Decorator" << endl;
     }
 };
 


### PR DESCRIPTION
fix: prevent memory leak by adding destructor in CharacterDecorator

Previously, only StarPowerUp defined a destructor, which caused leaks when Mario was wrapped with other decorators (e.g. HeightUp, GunPowerUp). Now CharacterDecorator deletes its wrapped Character, ensuring the entire decorator chain is cleaned up when the outermost object is deleted.